### PR TITLE
add html language attribute

### DIFF
--- a/extract_google_results.js
+++ b/extract_google_results.js
@@ -9,7 +9,7 @@ artoo.injectScript("//cdn.rawgit.com/eligrey/FileSaver.js/e9d941381475b5df8b7d76
   var loc = window.location,
     href = loc.href,
     query = href.replace(/^.*[#?&]q=([^#?&]+).*$/, '$1'),
-    hlang = (~href.search(/hl=/) ? href.replace(/^.*[#?&]hl=([^#?&]+).*$/, '$1') : 'fr'),
+    hlang = (~href.search(/hl=/) ? href.replace(/^.*[#?&]hl=([^#?&]+).*$/, '$1') : (($('html').lang) ? $('html').lang.substr(0,2) : 'fr')),
     total = (~href.search(/num=/) ? parseInt(href.replace(/^.*[#?&]num=(\d+).*$/, '$1')) : 100),
     start = (~href.search(/start=/) ? parseInt(href.replace(/^.*[#?&]start=(\d+).*$/, '$1')) : 0),
     page = start/total,

--- a/switch_classic_google.js
+++ b/switch_classic_google.js
@@ -2,7 +2,7 @@
   var loc = window.location,
     href = loc.href,
     query = (~href.search(/[#?&]q=/) ? href.replace(/^.*[#?&]q=([^#?&]+).*$/, '$1') : undefined),
-    hlang = (~href.search(/hl=/) ? href.replace(/^.*[#?&]hl=([^#?&]+).*$/, '$1') : 'fr'),
+    hlang = (~href.search(/hl=/) ? href.replace(/^.*[#?&]hl=([^#?&]+).*$/, '$1') : (($('html').lang) ? $('html').lang.substr(0,2) : 'fr')),
     total = (~href.search(/num=/) ? parseInt(href.replace(/^.*[#?&]num=(\d+).*$/, '$1')) : 100),
     languages = ['en', 'fr', 'it', 'es', 'pt', 'de', 'nl', 'ru', 'ar', 'fa', 'zh', 'ja', 'ko'],
     results = [10, 20, 50, 100],


### PR DESCRIPTION
Add the lang-attribute on the root element in addition to hl= to determine the current language.

This way it will list non-featured languages (e.g. Swedish) already when just entering a search result as `hl=` does not always seem to be present.